### PR TITLE
Fix NPE in MavenAdapterTest

### DIFF
--- a/jsparrow-maven-plugin/src/test/java/eu/jsparrow/maven/adapter/MavenAdapterTest.java
+++ b/jsparrow-maven-plugin/src/test/java/eu/jsparrow/maven/adapter/MavenAdapterTest.java
@@ -115,6 +115,7 @@ public class MavenAdapterTest {
 		when(jsparrowTempDirectory.exists()).thenReturn(false);
 		when(jsparrowTempDirectory.mkdirs()).thenReturn(true);
 		when(jsparrowTempDirectory.getAbsolutePath()).thenReturn(absolutePath);
+		when(jsparrowTempDirectory.toPath()).thenReturn(directory.getRoot().toPath());
 
 		mavenAdapter.prepareWorkingDirectory("");
 

--- a/jsparrow-maven-plugin/src/test/java/eu/jsparrow/maven/adapter/MavenAdapterTest.java
+++ b/jsparrow-maven-plugin/src/test/java/eu/jsparrow/maven/adapter/MavenAdapterTest.java
@@ -115,7 +115,7 @@ public class MavenAdapterTest {
 		when(jsparrowTempDirectory.exists()).thenReturn(false);
 		when(jsparrowTempDirectory.mkdirs()).thenReturn(true);
 		when(jsparrowTempDirectory.getAbsolutePath()).thenReturn(absolutePath);
-		when(jsparrowTempDirectory.toPath()).thenReturn(directory.getRoot().toPath());
+		when(jsparrowTempDirectory.toPath()).thenReturn(Path.of(absolutePath));
 
 		mavenAdapter.prepareWorkingDirectory("");
 


### PR DESCRIPTION
[prepareWorkingDirectory_directoryDoesNotExistAndMkdirsIsWorking](https://github.com/Splendit/simonykees/blob/10241c4aacdd7f8647a547b26fdb094ebe9f2c13/jsparrow-maven-plugin/src/test/java/eu/jsparrow/maven/adapter/MavenAdapterTest.java#L110-L124) is failing with the following exception:

>    java.lang.NullPointerException
>        at java.base/java.nio.file.Files.provider(Files.java:101)
>        ...
>        at
> eu.jsparrow.maven.adapter.MavenAdapter.logTempWorkspaceContents(MavenAdapter.java:246)
>        at
> eu.jsparrow.maven.adapter.MavenAdapter.prepareWorkingDirectory(MavenAdapter.java:211)
>        at
> eu.jsparrow.maven.adapter.MavenAdapterTest.prepareWorkingDirectory_directoryDoesNotExistAndMkdirsIsWorking(MavenAdapterTest.java:119)

This is happening because `MavenAdapter.prepareWorkingDirectory()` needs to access the path of the workspace root in
`MavenAdapter.logTempWorkspaceContents(File)` and the path is not being stubbed.

This PR solves this issue by adding the missing stub.