### PR TITLE
Fix jsparrow-maven-plugin build

### DIFF
--- a/features/feature.standalone/feature.xml
+++ b/features/feature.standalone/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="eu.jsparrow.standalone.feature"
       label="jSparrow"
-      version="4.19.0.qualifier"
+      version="4.20.0.qualifier"
       provider-name="Splendit IT-Consulting GmbH">
 
    <description url="https://jsparrow.github.io/">

--- a/features/feature.standalone/pom.xml
+++ b/features/feature.standalone/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>at.splendit</groupId>
 		<artifactId>features</artifactId>
-		<version>4.19.0-SNAPSHOT</version>
+		<version>4.20.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>eu.jsparrow.standalone.feature</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -18,8 +18,8 @@
 		<!-- OSGi feature + site deployment -->
 		<module>feature.3rd.party</module>
 
-		<!-- standalone 
-		<module>feature.standalone</module> -->
+		<!-- standalone -->
+		<module>feature.standalone</module>
 
 		<!-- eclipse plugin at least Photon -->
 		<module>feature.photon</module>

--- a/jsparrow-maven-plugin/pom.xml
+++ b/jsparrow-maven-plugin/pom.xml
@@ -101,7 +101,7 @@
  		<dependency>
 			<groupId>org.eclipse.platform</groupId>
 			<artifactId>org.eclipse.osgi</artifactId>
-			<version>3.16.300</version>
+			<version>3.17.200</version>
 		</dependency>
 
 		<dependency>

--- a/releng/eu.jsparrow.product/category.xml
+++ b/releng/eu.jsparrow.product/category.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/eu.jsparrow.standalone.feature_4.19.0.qualifier.jar" id="eu.jsparrow.standalone.feature" version="4.19.0.qualifier">
+   <feature url="features/eu.jsparrow.standalone.feature_4.20.0.qualifier.jar" id="eu.jsparrow.standalone.feature" version="4.20.0.qualifier">
       <category name="splendit"/>
    </feature>
-   <bundle id="org.eclipse.equinox.common" version="3.15.0">
+   <bundle id="org.eclipse.equinox.common" version="3.16.0">
       <category name="splendit"/>
    </bundle>
    <bundle id="org.eclipse.update.configurator" version="3.4.800">
       <category name="splendit"/>
    </bundle>
-   <bundle id="org.eclipse.equinox.launcher" version="1.6.200">
+   <bundle id="org.eclipse.equinox.launcher" version="1.6.400">
       <category name="splendit"/>
    </bundle>
    <category-def name="splendit" label="splendit">


### PR DESCRIPTION
[buildMavenPlugin.sh](https://github.com/Splendit/simonykees/blob/028876c7225d94e8adbea86e3bd1697c659a474c/buildMavenPlugin.sh) is failing with the following errors:

> cp: cannot stat 'releng/eu.jsparrow.product/target/repository/plugins/*': No such file or directory
> copying files from plugins to jsparrow-maven-plugin/src/main/resources failed!

This is happening for 2 reasons:
1. The `feature.standalone` module, which drives the product build, is commented out in the features reactor, preventing it from being built.
2. The versions of `feature.standalone` and the associated dependencies are outdated.

This PR addresses both of these issues.